### PR TITLE
README is wrong fixed it, and parsing of diff objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Cookbook used to setup POSIX filesystem ACL's on Linux.
 include_recipe 'facl'
 
 facl '/tmp/facl_test' do
-  user  :'' => 'rw', test_user: 'rwx'
-  group :'' => 'rw'
+  user  :'' => 'rw-', test_user: 'rwx'
+  group :'' => 'rw-'
   mask  :'' => 'rwx'
-  other :'' => 'r'
+  other :'' => 'r--'
 end
 ```
 
@@ -21,10 +21,10 @@ end
 include_recipe 'facl'
 
 facl '/tmp/facl_test_dir' do
-  user  :'' => 'rw', test_user: 'rwx'
-  group :'' => 'rw'
+  user  :'' => 'rw-', test_user: 'rwx'
+  group :'' => 'rw-'
   mask  :'' => 'rwx'
-  other :'' => 'r'
+  other :'' => 'r--'
 end
 ```
 
@@ -33,14 +33,14 @@ end
 include_recipe 'facl'
 
 facl '/tmp/facl_test_dir' do
-  user    :'' => 'rw', test_user: 'rwx'
-  group   :'' => 'rw'
+  user    :'' => 'rw-', test_user: 'rwx'
+  group   :'' => 'rw-'
   mask    :'' => 'rwx'
-  other   :'' => 'r'
-  default :user => { :'' => 'rw', test_user: 'rwx'}
-          :group => { :'' => 'rw' }
+  other   :'' => 'r--'
+  default :user => { :'' => 'rw-', test_user: 'rwx'}
+          :group => { :'' => 'rw-' }
           :mask => { :'' => 'rwx' }
-          :other => { :'' => 'r' }
+          :other => { :'' => 'r--' }
 end
 ```
 
@@ -53,10 +53,10 @@ include_recipe 'facl'
 end
 
 facl '/tmp/test' do
-  user  :'' => 'rw', test_user: 'rwx'
-  group :'' => 'rw'
+  user  :'' => 'rw-', test_user: 'rwx'
+  group :'' => 'rw-'
   mask  :'' => 'rwx'
-  other :'' => 'r'
+  other :'' => 'r--'
   recurse true
 end
 ```

--- a/resources/facl.rb
+++ b/resources/facl.rb
@@ -69,7 +69,9 @@ action :set do
   changes_required.each do |inst, obj|
     obj.each do |key, value|
       if recurse && ::File.directory?(new_resource.path)
-        setfacl(new_resource.path, inst, key, value, '-R')
+        converge_by("Setting ACL (#{inst}:#{key}:#{value}) on #{new_resource.path}") do
+          setfacl(new_resource.path, inst, key, value, '-R')
+        end
       else
         converge_by("Setting ACL (#{inst}:#{key}:#{value}) on #{new_resource.path}") do
           setfacl(new_resource.path, inst, key, value)
@@ -78,7 +80,9 @@ action :set do
     end
   end if changes_required
   default.each do |inst, obj|
+    next if obj.is_a?(Symbol)
     obj.each do |key, value|
+      next if value.is_a?(Symbol)
       raise 'Default ACL only valid on Directories!' unless ::File.directory?(new_resource.path)
       converge_by("Setting Default ACL (#{inst}:#{key}:#{value}) on #{new_resource.path}") do
         setfacl(new_resource.path, inst, key, value, '-d')


### PR DESCRIPTION
Since we changed default, the way the diff_acl reads these seems to be bit more complicated.

There's no hash since we go 1 level down now with the way we set the default object from the get-go since it's frozen. So to work around this, we skip anytime a ":remove" Symbol appears, and just focus on the String objects that come through which symbolize an actual change. 

Also sets off the converge flag to let chef know a change is being made if necessary.

README also is a bit wrong, we should be putting in a "-" in place of a missing permission, rather than omitting it completely, since that matches getfacl's output accurately in a chef converge.